### PR TITLE
Added a urdf file for the ease of laser scan visualization

### DIFF
--- a/launch/hokuyo_laser.urdf
+++ b/launch/hokuyo_laser.urdf
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<robot name="hokuyo_laser">
+
+  <link name="world"/>
+
+  <joint name="world_to_laser_fixed" type="fixed">
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <parent link="world"/>
+    <child link="laser"/>
+  </joint>
+
+  <link name="laser">
+  <visual>
+    <origin rpy="0 0 0" xyz="0 0 0"/>
+    <geometry>
+      <box size="0.1 0.1 0.1"/>
+    </geometry>
+  </visual>
+  </link>
+
+</robot>


### PR DESCRIPTION
Can easily visualize the laserscan by running the following command along with the urg node and rviz2: 

```ros2 run robot_state_publisher robot_state_publisher <path to ros2 workspace>/install/share/dummy_sensors/launch/hokuyo_laser.urdf```

Set the fixed frame to 'world' in rviz2.